### PR TITLE
add fuzzing

### DIFF
--- a/fuzzing/Makefile
+++ b/fuzzing/Makefile
@@ -1,0 +1,12 @@
+FLAGS:=-g -fsanitize=address,undefined,fuzzer -fno-sanitize-recover=all -I.. -std=c++20
+CXX:=clang++-14
+
+all: fuzzer_decompress0 fuzzer_compress0 fuzzer_roundtrip0
+
+fuzzer_decompress0: fuzzer_decompress.cpp ../lzav.h
+	$(CXX) $(FLAGS) -O0 $< -o $@
+fuzzer_compress0: fuzzer_compress.cpp ../lzav.h
+	$(CXX) $(FLAGS) -O0 $< -o $@
+fuzzer_roundtrip0: fuzzer_roundtrip.cpp ../lzav.h
+	$(CXX) $(FLAGS) -O0 $< -o $@
+

--- a/fuzzing/fuzzer_compress.cpp
+++ b/fuzzing/fuzzer_compress.cpp
@@ -1,0 +1,24 @@
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+#include "lzav.h"
+
+/*
+ * This takes a buffer with arbrirtrary data and compresses it.
+ */
+extern "C" int
+LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+
+  const int comp_len_max = 20000;
+  char comp_buf[comp_len_max];
+
+  const int max_len = lzav_compress_bound(Size);
+  if (max_len <= comp_len_max) {
+    int comp_len = lzav_compress_default(Data, comp_buf, Size, comp_len_max);
+    assert(comp_len >= 0);
+  }
+
+  return 0;
+}

--- a/fuzzing/fuzzer_decompress.cpp
+++ b/fuzzing/fuzzer_decompress.cpp
@@ -1,0 +1,20 @@
+#include <cstddef>
+#include <cstdint>
+
+#include "lzav.h"
+
+/*
+ * This takes a buffer supposedly containing compressed data
+ * and decompresses it.
+ */
+extern "C" int
+LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+
+  const int comp_len = 20000;
+  char decomp_buf[comp_len];
+
+  const int l = lzav_decompress(Data, decomp_buf, Size, comp_len);
+
+  return 0;
+}

--- a/fuzzing/fuzzer_roundtrip.cpp
+++ b/fuzzing/fuzzer_roundtrip.cpp
@@ -1,0 +1,36 @@
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "lzav.h"
+
+/*
+ * This takes a buffer with arbitrary data and compresses it,
+ * decompresses it and makes sure it is identical to the original.
+ */
+extern "C" int
+LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+
+  const int comp_len_max = 20000;
+  char comp_buf[comp_len_max];
+
+  const int max_len = lzav_compress_bound(Size);
+  if (max_len > comp_len_max) {
+    return 0;
+  }
+  const int comp_len =
+    lzav_compress_default(Data, comp_buf, Size, comp_len_max);
+  assert(comp_len >= 0);
+
+  // decompress it
+  const int decomp_len = 20000;
+  char decomp_buf[decomp_len];
+
+  const int l = lzav_decompress(comp_buf, decomp_buf, comp_len, decomp_len);
+
+  assert(0 == std::memcmp(Data, decomp_buf, Size));
+
+  return 0;
+}

--- a/lzav.h
+++ b/lzav.h
@@ -926,8 +926,8 @@ static inline int lzav_decompress( const void* const src, void* const dst,
 
 					if( LZAV_LIKELY( op < opet ))
 					{
-						memcpy( op, ipd, 16 );
-						memcpy( op + 16, ipd + 16, 4 );
+						memmove( op, ipd, 16 );
+						memmove( op + 16, ipd + 16, 4 );
 						op += cc;
 						continue;
 					}
@@ -942,8 +942,8 @@ static inline int lzav_decompress( const void* const src, void* const dst,
 
 					if( LZAV_LIKELY( op < opet ))
 					{
-						memcpy( op, ipd, 16 );
-						memcpy( op + 16, ipd + 16, 4 );
+						memmove( op, ipd, 16 );
+						memmove( op + 16, ipd + 16, 4 );
 						op += cc;
 						continue;
 					}
@@ -986,8 +986,8 @@ static inline int lzav_decompress( const void* const src, void* const dst,
 
 					if( LZAV_LIKELY( op < opet ))
 					{
-						memcpy( op, ipd, 16 );
-						memcpy( op + 16, ipd + 16, 4 );
+						memmove( op, ipd, 16 );
+						memmove( op + 16, ipd + 16, 4 );
 						op += cc;
 						continue;
 					}
@@ -1049,10 +1049,10 @@ static inline int lzav_decompress( const void* const src, void* const dst,
 
 			if( LZAV_LIKELY( op < opet ))
 			{
-				memcpy( op, ipd, 16 );
-				memcpy( op + 16, ipd + 16, 16 );
-				memcpy( op + 32, ipd + 32, 16 );
-				memcpy( op + 48, ipd + 48, 16 );
+				memmove( op, ipd, 16 );
+				memmove( op + 16, ipd + 16, 16 );
+				memmove( op + 32, ipd + 32, 16 );
+				memmove( op + 48, ipd + 48, 16 );
 
 				if( LZAV_LIKELY( cc <= 64 ))
 				{


### PR DESCRIPTION
Hi, 
I fuzzed compression, decompression and added a fuzz test for correct roundtripping.

The only error I found was that the memory ranges passed to memcpy could be overlapping,
which is UB.

I am happy to contribute the files to match the license you use in the project.